### PR TITLE
Auth plugin: login, register, logout, change-password, forgot/reset password

### DIFF
--- a/fiat_lux_agents/__init__.py
+++ b/fiat_lux_agents/__init__.py
@@ -27,6 +27,11 @@ try:
 except ImportError:
     MCPClient = None
 
+try:
+    from .auth import make_auth_blueprint
+except ImportError:
+    make_auth_blueprint = None
+
 __all__ = [
     "LLMBase",
     "clean_json_string",
@@ -53,4 +58,5 @@ __all__ = [
     "make_explorer_blueprint",
     "make_data_lake_explorer_blueprint",
     "MCPClient",
+    "make_auth_blueprint",
 ]

--- a/fiat_lux_agents/auth/__init__.py
+++ b/fiat_lux_agents/auth/__init__.py
@@ -1,0 +1,4 @@
+from .blueprint import make_auth_blueprint
+from .db import AuthDB, hash_password, verify_password
+
+__all__ = ["make_auth_blueprint", "AuthDB", "hash_password", "verify_password"]

--- a/fiat_lux_agents/auth/blueprint.py
+++ b/fiat_lux_agents/auth/blueprint.py
@@ -1,0 +1,105 @@
+"""Flask blueprint factory for fla-auth.
+
+Usage in app.py:
+    from fiat_lux_agents.auth import make_auth_blueprint
+    from database.connection import get_db, USE_POSTGRES
+
+    auth_bp = make_auth_blueprint(
+        get_connection=get_db,
+        use_postgres=USE_POSTGRES,
+        invite_code=os.environ.get("INVITE_CODE", ""),
+    )
+    app.register_blueprint(auth_bp)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Callable
+
+from flask import Blueprint, jsonify, request, session
+
+from .db import AuthDB
+from . import handlers
+
+
+def make_auth_blueprint(
+    get_connection: Callable,
+    use_postgres: bool = False,
+    invite_code: str = "",
+    url_prefix: str = "/api",
+    blueprint_name: str = "fla_auth",
+) -> Blueprint:
+    """Return a configured auth blueprint.
+
+    Args:
+        get_connection: callable returning a context manager for a DB connection
+        use_postgres:   True if the DB uses %s placeholders (Postgres), False for ? (SQLite)
+        invite_code:    if set, required on registration
+        url_prefix:     prefix for all routes (default /api)
+        blueprint_name: Flask blueprint name (change if registering multiple times)
+    """
+    db = AuthDB(get_connection, use_postgres)
+    bp = Blueprint(blueprint_name, __name__, template_folder="templates")
+
+    def _ok(data: dict) -> tuple:
+        return jsonify({"success": True, **data}), 200
+
+    def _err(message: str, status: int = 400) -> tuple:
+        return jsonify({"success": False, "error": message}), status
+
+    @bp.post(f"{url_prefix}/login")
+    def login():
+        data = request.get_json(silent=True) or {}
+        user, error = handlers.login(
+            db,
+            data.get("username", ""),
+            data.get("password", ""),
+        )
+        if error:
+            return _err(error, 401 if "Invalid" in error else 400)
+        session["user_id"] = user["id"]
+        session["username"] = user["username"]
+        return _ok({"username": user["username"]})
+
+    @bp.post(f"{url_prefix}/register")
+    def register():
+        data = request.get_json(silent=True) or {}
+        success, error = handlers.register(
+            db,
+            username=data.get("username", ""),
+            email=data.get("email", ""),
+            password=data.get("password", ""),
+            invite_code=data.get("invite_code", ""),
+            required_invite_code=invite_code,
+        )
+        if success:
+            ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            print(f"[fla-auth][SIGNUP] {data.get('username', '').strip()} @ {ts}", flush=True)
+            return _ok({})
+        return _err(error)
+
+    @bp.post(f"{url_prefix}/logout")
+    def logout():
+        session.clear()
+        return _ok({})
+
+    @bp.post(f"{url_prefix}/user/change-password")
+    def change_password():
+        user_id = session.get("user_id")
+        if not user_id:
+            return _err("Not logged in", 401)
+        data = request.get_json(silent=True) or {}
+        success, error = handlers.change_password(
+            db,
+            user_id=user_id,
+            current_password=data.get("current_password", ""),
+            new_password=data.get("new_password", ""),
+            confirm_password=data.get("confirm_password", ""),
+        )
+        if success:
+            return _ok({})
+        return _err(error)
+
+    return bp

--- a/fiat_lux_agents/auth/blueprint.py
+++ b/fiat_lux_agents/auth/blueprint.py
@@ -8,13 +8,15 @@ Usage in app.py:
         get_connection=get_db,
         use_postgres=USE_POSTGRES,
         invite_code=os.environ.get("INVITE_CODE", ""),
+        secret_key=os.environ["SECRET_KEY"],
+        app_url="https://libertas-travel.onrender.com",
+        from_email="noreply@libertas-travel.onrender.com",
     )
     app.register_blueprint(auth_bp)
 """
 
 from __future__ import annotations
 
-import os
 from datetime import UTC, datetime
 from typing import Callable
 
@@ -28,6 +30,10 @@ def make_auth_blueprint(
     get_connection: Callable,
     use_postgres: bool = False,
     invite_code: str = "",
+    secret_key: str = "",
+    app_url: str = "",
+    from_email: str = "",
+    app_name: str = "Libertas",
     url_prefix: str = "/api",
     blueprint_name: str = "fla_auth",
 ) -> Blueprint:
@@ -37,6 +43,10 @@ def make_auth_blueprint(
         get_connection: callable returning a context manager for a DB connection
         use_postgres:   True if the DB uses %s placeholders (Postgres), False for ? (SQLite)
         invite_code:    if set, required on registration
+        secret_key:     HMAC key for reset tokens (use app SECRET_KEY)
+        app_url:        base URL for reset links, e.g. https://libertas-travel.onrender.com
+        from_email:     sender address for reset emails
+        app_name:       app name shown in emails
         url_prefix:     prefix for all routes (default /api)
         blueprint_name: Flask blueprint name (change if registering multiple times)
     """
@@ -97,6 +107,39 @@ def make_auth_blueprint(
             current_password=data.get("current_password", ""),
             new_password=data.get("new_password", ""),
             confirm_password=data.get("confirm_password", ""),
+        )
+        if success:
+            return _ok({})
+        return _err(error)
+
+    @bp.post(f"{url_prefix}/forgot-password")
+    def forgot_password():
+        if not secret_key or not app_url or not from_email:
+            return _err("Password reset is not configured", 503)
+        data = request.get_json(silent=True) or {}
+        success, error = handlers.forgot_password(
+            db,
+            email=data.get("email", ""),
+            secret_key=secret_key,
+            app_url=app_url,
+            from_email=from_email,
+            app_name=app_name,
+        )
+        if success:
+            return _ok({})
+        return _err(error)
+
+    @bp.post(f"{url_prefix}/reset-password")
+    def reset_password():
+        if not secret_key:
+            return _err("Password reset is not configured", 503)
+        data = request.get_json(silent=True) or {}
+        success, error = handlers.reset_password(
+            db,
+            token=data.get("token", ""),
+            new_password=data.get("new_password", ""),
+            confirm_password=data.get("confirm_password", ""),
+            secret_key=secret_key,
         )
         if success:
             return _ok({})

--- a/fiat_lux_agents/auth/db.py
+++ b/fiat_lux_agents/auth/db.py
@@ -161,3 +161,14 @@ class AuthDB:
                 (new_hash, user_id),
             )
             return True, None
+
+    def set_password_by_id(self, user_id: int, new_password: str) -> bool:
+        """Set password directly by user ID - used after token verification."""
+        new_hash = hash_password(new_password)
+        with self._get() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                self._p(_SQL_PG_SET_PASSWORD, _SQL_SQ_SET_PASSWORD),
+                (new_hash, user_id),
+            )
+            return cur.rowcount > 0

--- a/fiat_lux_agents/auth/db.py
+++ b/fiat_lux_agents/auth/db.py
@@ -1,0 +1,163 @@
+"""Auth DB helpers - create/verify users, change passwords.
+
+Designed to work with any connection factory that returns a context manager
+yielding a DBAPI2 connection. Caller passes ``get_connection`` and
+``use_postgres`` so the plugin stays decoupled from the app's DB layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import bcrypt
+
+# --- SQL constants ---
+
+_SQL_PG_INSERT_USER = (
+    "INSERT INTO users (username, email, password_hash)"
+    " VALUES (%s, %s, %s) RETURNING id"
+)
+_SQL_SQ_INSERT_USER = (
+    "INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)"
+)
+
+_SQL_PG_GET_BY_USERNAME = (
+    "SELECT id, username, email, password_hash FROM users WHERE username = %s"
+)
+_SQL_SQ_GET_BY_USERNAME = (
+    "SELECT id, username, email, password_hash FROM users WHERE username = ?"
+)
+
+_SQL_PG_GET_BY_EMAIL = (
+    "SELECT id, username, email, password_hash FROM users WHERE email = %s"
+)
+_SQL_SQ_GET_BY_EMAIL = (
+    "SELECT id, username, email, password_hash FROM users WHERE email = ?"
+)
+
+_SQL_PG_USERNAME_EXISTS = "SELECT 1 FROM users WHERE username = %s"
+_SQL_SQ_USERNAME_EXISTS = "SELECT 1 FROM users WHERE username = ?"
+
+_SQL_PG_EMAIL_EXISTS = "SELECT 1 FROM users WHERE email = %s"
+_SQL_SQ_EMAIL_EXISTS = "SELECT 1 FROM users WHERE email = ?"
+
+_SQL_PG_SET_PASSWORD = "UPDATE users SET password_hash = %s WHERE id = %s"
+_SQL_SQ_SET_PASSWORD = "UPDATE users SET password_hash = ? WHERE id = ?"
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    return bcrypt.checkpw(password.encode(), password_hash.encode())
+
+
+def _row_to_user(row, use_postgres: bool) -> dict[str, Any]:
+    if use_postgres:
+        return {
+            "id": row[0],
+            "username": row[1],
+            "email": row[2],
+            "password_hash": row[3],
+        }
+    return dict(row)
+
+
+class AuthDB:
+    """Thin wrapper that binds a connection factory to the SQL helpers."""
+
+    def __init__(self, get_connection: Callable, use_postgres: bool = False):
+        self._get = get_connection
+        self._pg = use_postgres
+
+    def _p(self, pg_sql: str, sq_sql: str) -> str:
+        return pg_sql if self._pg else sq_sql
+
+    def create_user(self, username: str, email: str, password: str) -> int | None:
+        password_hash = hash_password(password)
+        with self._get() as conn:
+            cur = conn.cursor()
+            try:
+                if self._pg:
+                    cur.execute(_SQL_PG_INSERT_USER, (username, email, password_hash))
+                    return cur.fetchone()[0]
+                else:
+                    cur.execute(_SQL_SQ_INSERT_USER, (username, email, password_hash))
+                    return cur.lastrowid
+            except Exception as e:
+                print(f"[fla-auth] create_user failed: {e}")
+                return None
+
+    def get_user_by_username(self, username: str) -> dict[str, Any] | None:
+        with self._get() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                self._p(_SQL_PG_GET_BY_USERNAME, _SQL_SQ_GET_BY_USERNAME),
+                (username,),
+            )
+            row = cur.fetchone()
+            return _row_to_user(row, self._pg) if row else None
+
+    def get_user_by_email(self, email: str) -> dict[str, Any] | None:
+        with self._get() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                self._p(_SQL_PG_GET_BY_EMAIL, _SQL_SQ_GET_BY_EMAIL),
+                (email,),
+            )
+            row = cur.fetchone()
+            return _row_to_user(row, self._pg) if row else None
+
+    def username_exists(self, username: str) -> bool:
+        with self._get() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                self._p(_SQL_PG_USERNAME_EXISTS, _SQL_SQ_USERNAME_EXISTS),
+                (username,),
+            )
+            return cur.fetchone() is not None
+
+    def email_exists(self, email: str) -> bool:
+        with self._get() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                self._p(_SQL_PG_EMAIL_EXISTS, _SQL_SQ_EMAIL_EXISTS),
+                (email,),
+            )
+            return cur.fetchone() is not None
+
+    def authenticate(self, username: str, password: str) -> dict[str, Any] | None:
+        user = self.get_user_by_username(username)
+        if user and verify_password(password, user["password_hash"]):
+            user = dict(user)
+            del user["password_hash"]
+            return user
+        return None
+
+    def change_password(
+        self, user_id: int, current_password: str, new_password: str
+    ) -> tuple[bool, str | None]:
+        """Verify current password then set new one. Returns (ok, error)."""
+        with self._get() as conn:
+            cur = conn.cursor()
+            if self._pg:
+                cur.execute(
+                    "SELECT password_hash FROM users WHERE id = %s", (user_id,)
+                )
+            else:
+                cur.execute(
+                    "SELECT password_hash FROM users WHERE id = ?", (user_id,)
+                )
+            row = cur.fetchone()
+            if not row:
+                return False, "User not found"
+            stored_hash = row[0] if self._pg else row["password_hash"]
+            if not verify_password(current_password, stored_hash):
+                return False, "Current password is incorrect"
+            new_hash = hash_password(new_password)
+            cur.execute(
+                self._p(_SQL_PG_SET_PASSWORD, _SQL_SQ_SET_PASSWORD),
+                (new_hash, user_id),
+            )
+            return True, None

--- a/fiat_lux_agents/auth/email.py
+++ b/fiat_lux_agents/auth/email.py
@@ -1,0 +1,80 @@
+"""Email sender abstraction for fla-auth.
+
+Configured via env vars at send time:
+  SENDGRID_API_KEY  - if set, sends via Sendgrid HTTP API
+  SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASS - fallback SMTP
+
+Neither set? send() raises RuntimeError so the caller can surface a
+useful error rather than silently swallowing it.
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+def send(to: str, subject: str, body_html: str, from_email: str) -> None:
+    """Send an email. Raises RuntimeError if no provider is configured."""
+    api_key = os.environ.get("SENDGRID_API_KEY", "")
+    if api_key:
+        _send_sendgrid(api_key, from_email, to, subject, body_html)
+        return
+
+    smtp_host = os.environ.get("SMTP_HOST", "")
+    if smtp_host:
+        _send_smtp(smtp_host, from_email, to, subject, body_html)
+        return
+
+    raise RuntimeError(
+        "No email provider configured. Set SENDGRID_API_KEY or SMTP_HOST."
+    )
+
+
+def _send_sendgrid(
+    api_key: str, from_email: str, to: str, subject: str, body_html: str
+) -> None:
+    import urllib.request
+    import json
+
+    payload = json.dumps({
+        "personalizations": [{"to": [{"email": to}]}],
+        "from": {"email": from_email},
+        "subject": subject,
+        "content": [{"type": "text/html", "value": body_html}],
+    }).encode()
+
+    req = urllib.request.Request(
+        "https://api.sendgrid.com/v3/mail/send",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        if resp.status not in (200, 202):
+            raise RuntimeError(f"Sendgrid returned {resp.status}")
+
+
+def _send_smtp(
+    smtp_host: str, from_email: str, to: str, subject: str, body_html: str
+) -> None:
+    smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+    smtp_user = os.environ.get("SMTP_USER", "")
+    smtp_pass = os.environ.get("SMTP_PASS", "")
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = from_email
+    msg["To"] = to
+    msg.attach(MIMEText(body_html, "html"))
+
+    with smtplib.SMTP(smtp_host, smtp_port) as server:
+        server.starttls()
+        if smtp_user:
+            server.login(smtp_user, smtp_pass)
+        server.sendmail(from_email, to, msg.as_string())

--- a/fiat_lux_agents/auth/handlers.py
+++ b/fiat_lux_agents/auth/handlers.py
@@ -59,6 +59,74 @@ def login(
     return user, None
 
 
+def forgot_password(
+    db: AuthDB,
+    email: str,
+    secret_key: str,
+    app_url: str,
+    from_email: str,
+    app_name: str = "Libertas",
+) -> tuple[bool, str | None]:
+    """Look up user by email, send reset link. Returns (sent, error).
+
+    Always returns (True, None) even if email not found - avoids leaking
+    whether an address is registered.
+    """
+    from .tokens import generate_reset_token
+    from . import email as mailer
+
+    email = email.strip().lower()
+    user = db.get_user_by_email(email)
+    if not user:
+        return True, None  # silent - don't reveal if email exists
+
+    token = generate_reset_token(user["id"], secret_key)
+    reset_url = f"{app_url.rstrip('/')}/reset-password.html?token={token}"
+
+    body = f"""
+<p>Hi {user['username']},</p>
+<p>Someone requested a password reset for your {app_name} account.</p>
+<p><a href="{reset_url}" style="background:#667eea;color:white;padding:12px 24px;
+border-radius:8px;text-decoration:none;font-weight:600;">Reset Password</a></p>
+<p>This link expires in 1 hour. If you didn't request this, ignore this email.</p>
+<p>{app_name}</p>
+"""
+    try:
+        mailer.send(email, f"Reset your {app_name} password", body, from_email)
+    except Exception as e:
+        print(f"[fla-auth] email send failed: {e}")
+        return False, "Failed to send reset email - please try again later"
+
+    return True, None
+
+
+def reset_password(
+    db: AuthDB,
+    token: str,
+    new_password: str,
+    confirm_password: str,
+    secret_key: str,
+) -> tuple[bool, str | None]:
+    """Verify token and set new password. Returns (success, error)."""
+    from .tokens import verify_reset_token
+
+    if not new_password or not confirm_password:
+        return False, "All fields are required"
+    if new_password != confirm_password:
+        return False, "Passwords do not match"
+    if len(new_password) < MIN_PASSWORD_LEN:
+        return False, f"Password must be at least {MIN_PASSWORD_LEN} characters"
+
+    user_id = verify_reset_token(token, secret_key)
+    if not user_id:
+        return False, "Reset link is invalid or has expired"
+
+    ok = db.set_password_by_id(user_id, new_password)
+    if not ok:
+        return False, "Failed to reset password"
+    return True, None
+
+
 def change_password(
     db: AuthDB,
     user_id: int,

--- a/fiat_lux_agents/auth/handlers.py
+++ b/fiat_lux_agents/auth/handlers.py
@@ -1,0 +1,76 @@
+"""Auth business logic - registration, login, change-password."""
+
+from __future__ import annotations
+
+from .db import AuthDB
+
+MIN_USERNAME_LEN = 3
+MIN_PASSWORD_LEN = 6
+
+
+def register(
+    db: AuthDB,
+    username: str,
+    email: str,
+    password: str,
+    invite_code: str = "",
+    required_invite_code: str = "",
+) -> tuple[bool, str | None]:
+    """Validate and create a new user. Returns (success, error_message)."""
+    username = username.strip()
+    email = email.strip()
+    password = password.strip()
+
+    if len(username) < MIN_USERNAME_LEN:
+        return False, f"Username must be at least {MIN_USERNAME_LEN} characters"
+    if not email or "@" not in email:
+        return False, "Invalid email address"
+    if len(password) < MIN_PASSWORD_LEN:
+        return False, f"Password must be at least {MIN_PASSWORD_LEN} characters"
+
+    if required_invite_code:
+        if not invite_code:
+            return False, "An invite code is required to register"
+        if invite_code != required_invite_code:
+            return False, "Invalid invite code"
+
+    if db.username_exists(username):
+        return False, "Username already taken"
+    if db.email_exists(email):
+        return False, "Email already registered"
+
+    user_id = db.create_user(username, email, password)
+    if user_id:
+        return True, None
+    return False, "Failed to create user"
+
+
+def login(
+    db: AuthDB, username: str, password: str
+) -> tuple[dict | None, str | None]:
+    """Authenticate. Returns (user_dict, None) or (None, error_message)."""
+    username = username.strip()
+    password = password.strip()
+    if not username or not password:
+        return None, "Username and password required"
+    user = db.authenticate(username, password)
+    if not user:
+        return None, "Invalid username or password"
+    return user, None
+
+
+def change_password(
+    db: AuthDB,
+    user_id: int,
+    current_password: str,
+    new_password: str,
+    confirm_password: str,
+) -> tuple[bool, str | None]:
+    """Validate and change a user's password. Returns (success, error)."""
+    if not current_password or not new_password or not confirm_password:
+        return False, "All fields are required"
+    if new_password != confirm_password:
+        return False, "New passwords do not match"
+    if len(new_password) < MIN_PASSWORD_LEN:
+        return False, f"Password must be at least {MIN_PASSWORD_LEN} characters"
+    return db.change_password(user_id, current_password, new_password)

--- a/fiat_lux_agents/auth/tokens.py
+++ b/fiat_lux_agents/auth/tokens.py
@@ -1,0 +1,52 @@
+"""Stateless HMAC reset tokens - no extra DB table needed.
+
+Token format: base64url(user_id:timestamp):hmac_hex
+Expiry is checked at verification time.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+
+DEFAULT_EXPIRY_SECONDS = 3600  # 1 hour
+
+
+def _encode(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=")
+
+
+def _decode(value: str) -> str:
+    padding = 4 - len(value) % 4
+    return base64.urlsafe_b64decode(value + "=" * padding).decode()
+
+
+def generate_reset_token(user_id: int, secret_key: str) -> str:
+    ts = int(time.time())
+    payload = f"{user_id}:{ts}"
+    sig = hmac.new(secret_key.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return f"{_encode(payload)}.{sig}"
+
+
+def verify_reset_token(
+    token: str,
+    secret_key: str,
+    expiry_seconds: int = DEFAULT_EXPIRY_SECONDS,
+) -> int | None:
+    """Return user_id if token is valid and unexpired, else None."""
+    try:
+        encoded_payload, sig = token.rsplit(".", 1)
+        payload = _decode(encoded_payload)
+        user_id_str, ts_str = payload.split(":")
+        expected_sig = hmac.new(
+            secret_key.encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()
+        if not hmac.compare_digest(sig, expected_sig):
+            return None
+        if time.time() - int(ts_str) > expiry_seconds:
+            return None
+        return int(user_id_str)
+    except Exception:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,16 @@ dependencies = [
 mcp = [
     "mcp>=1.0.0",
 ]
+auth = [
+    "flask>=3.0.0",
+    "bcrypt>=4.0.0",
+]
 dev = [
     "pytest>=7.4.0",
     "pytest-dotenv>=0.5.2",
     "mcp>=1.0.0",
+    "flask>=3.0.0",
+    "bcrypt>=4.0.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -37,4 +43,5 @@ include = ["fiat_lux_agents*"]
     "explorer/templates/*.html",
     "explorer/static/*.js",
     "explorer/static/*.css",
+    "auth/templates/auth/*.html",
 ]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -47,12 +47,21 @@ def auth_db(mem_db_factory):
     return AuthDB(mem_db_factory, use_postgres=False)
 
 
+_SECRET = "test-secret"
+
+
 @pytest.fixture
 def client(mem_db_factory):
     app = Flask(__name__)
-    app.secret_key = "test-secret"
+    app.secret_key = _SECRET
     app.config["TESTING"] = True
-    bp = make_auth_blueprint(mem_db_factory, use_postgres=False)
+    bp = make_auth_blueprint(
+        mem_db_factory,
+        use_postgres=False,
+        secret_key=_SECRET,
+        app_url="http://localhost",
+        from_email="noreply@test.local",
+    )
     app.register_blueprint(bp)
     with app.test_client() as c:
         yield c
@@ -214,6 +223,89 @@ class TestBlueprint:
         })
         assert r.status_code == 200
         assert r.get_json()["success"] is True
-        # old password no longer works
         assert auth_db.authenticate("nick", "oldpass1") is None
         assert auth_db.authenticate("nick", "newpass1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Token tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokens:
+    def test_valid_token_round_trip(self):
+        from fiat_lux_agents.auth.tokens import generate_reset_token, verify_reset_token
+        token = generate_reset_token(42, "secret")
+        assert verify_reset_token(token, "secret") == 42
+
+    def test_wrong_secret_rejected(self):
+        from fiat_lux_agents.auth.tokens import generate_reset_token, verify_reset_token
+        token = generate_reset_token(42, "secret")
+        assert verify_reset_token(token, "wrong-secret") is None
+
+    def test_expired_token_rejected(self):
+        from fiat_lux_agents.auth.tokens import generate_reset_token, verify_reset_token
+        token = generate_reset_token(42, "secret")
+        assert verify_reset_token(token, "secret", expiry_seconds=0) is None
+
+    def test_tampered_token_rejected(self):
+        from fiat_lux_agents.auth.tokens import generate_reset_token, verify_reset_token
+        token = generate_reset_token(42, "secret")
+        tampered = token[:-4] + "xxxx"
+        assert verify_reset_token(tampered, "secret") is None
+
+
+# ---------------------------------------------------------------------------
+# Reset-password route tests
+# ---------------------------------------------------------------------------
+
+
+class TestResetPasswordRoutes:
+    def test_forgot_password_unknown_email_still_200(self, client):
+        r = client.post("/api/forgot-password", json={"email": "nobody@example.com"})
+        assert r.status_code == 200
+        assert r.get_json()["success"] is True
+
+    def test_forgot_password_sends_for_known_email(self, auth_db, client, monkeypatch):
+        import fiat_lux_agents.auth.email as mailer
+        sent = []
+        monkeypatch.setattr(mailer, "send", lambda *a, **kw: sent.append(a))
+        auth_db.create_user("olivia", "olivia@example.com", "pass123")
+        r = client.post("/api/forgot-password", json={"email": "olivia@example.com"})
+        assert r.status_code == 200
+        assert len(sent) == 1
+        assert "olivia@example.com" in sent[0]
+
+    def test_reset_password_valid_token(self, auth_db, client):
+        from fiat_lux_agents.auth.tokens import generate_reset_token
+        uid = auth_db.create_user("pete", "pete@example.com", "oldpass1")
+        token = generate_reset_token(uid, _SECRET)
+        r = client.post("/api/reset-password", json={
+            "token": token,
+            "new_password": "brandnew1",
+            "confirm_password": "brandnew1",
+        })
+        assert r.status_code == 200
+        assert r.get_json()["success"] is True
+        assert auth_db.authenticate("pete", "brandnew1") is not None
+        assert auth_db.authenticate("pete", "oldpass1") is None
+
+    def test_reset_password_invalid_token(self, client):
+        r = client.post("/api/reset-password", json={
+            "token": "bad.token",
+            "new_password": "brandnew1",
+            "confirm_password": "brandnew1",
+        })
+        assert r.status_code == 400
+        assert "expired" in r.get_json()["error"].lower() or "invalid" in r.get_json()["error"].lower()
+
+    def test_reset_password_mismatch(self, auth_db, client):
+        from fiat_lux_agents.auth.tokens import generate_reset_token
+        uid = auth_db.create_user("quinn", "quinn@example.com", "pass123")
+        token = generate_reset_token(uid, _SECRET)
+        r = client.post("/api/reset-password", json={
+            "token": token,
+            "new_password": "newpass1",
+            "confirm_password": "different1",
+        })
+        assert r.status_code == 400

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,219 @@
+"""Tests for fiat_lux_agents.auth plugin."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+
+import pytest
+from flask import Flask
+
+from fiat_lux_agents.auth import make_auth_blueprint
+from fiat_lux_agents.auth.db import AuthDB, hash_password, verify_password
+from fiat_lux_agents.auth import handlers
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite fixture
+# ---------------------------------------------------------------------------
+
+_CREATE_USERS = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL
+)
+"""
+
+
+@pytest.fixture
+def mem_db_factory():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(_CREATE_USERS)
+    conn.commit()
+
+    @contextlib.contextmanager
+    def get_connection():
+        yield conn
+
+    yield get_connection
+    conn.close()
+
+
+@pytest.fixture
+def auth_db(mem_db_factory):
+    return AuthDB(mem_db_factory, use_postgres=False)
+
+
+@pytest.fixture
+def client(mem_db_factory):
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    bp = make_auth_blueprint(mem_db_factory, use_postgres=False)
+    app.register_blueprint(bp)
+    with app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# AuthDB unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHashAndVerify:
+    def test_round_trip(self):
+        h = hash_password("hello123")
+        assert verify_password("hello123", h)
+
+    def test_wrong_password(self):
+        h = hash_password("hello123")
+        assert not verify_password("wrong", h)
+
+
+class TestAuthDB:
+    def test_create_and_authenticate(self, auth_db):
+        uid = auth_db.create_user("alice", "alice@example.com", "secret99")
+        assert uid is not None
+        user = auth_db.authenticate("alice", "secret99")
+        assert user is not None
+        assert user["username"] == "alice"
+        assert "password_hash" not in user
+
+    def test_authenticate_wrong_password(self, auth_db):
+        auth_db.create_user("bob", "bob@example.com", "rightpass")
+        assert auth_db.authenticate("bob", "wrongpass") is None
+
+    def test_username_exists(self, auth_db):
+        auth_db.create_user("carol", "carol@example.com", "pass123")
+        assert auth_db.username_exists("carol")
+        assert not auth_db.username_exists("nobody")
+
+    def test_email_exists(self, auth_db):
+        auth_db.create_user("dave", "dave@example.com", "pass123")
+        assert auth_db.email_exists("dave@example.com")
+        assert not auth_db.email_exists("other@example.com")
+
+    def test_change_password(self, auth_db):
+        uid = auth_db.create_user("eve", "eve@example.com", "oldpass1")
+        ok, err = auth_db.change_password(uid, "oldpass1", "newpass1")
+        assert ok
+        assert auth_db.authenticate("eve", "newpass1") is not None
+        assert auth_db.authenticate("eve", "oldpass1") is None
+
+    def test_change_password_wrong_current(self, auth_db):
+        uid = auth_db.create_user("frank", "frank@example.com", "pass123")
+        ok, err = auth_db.change_password(uid, "wrongcurrent", "newpass1")
+        assert not ok
+        assert "incorrect" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Handler unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandlers:
+    def test_register_valid(self, auth_db):
+        ok, err = handlers.register(auth_db, "grace", "grace@example.com", "pass123")
+        assert ok
+        assert err is None
+
+    def test_register_short_username(self, auth_db):
+        ok, err = handlers.register(auth_db, "ab", "ab@example.com", "pass123")
+        assert not ok
+        assert "Username" in err
+
+    def test_register_invalid_email(self, auth_db):
+        ok, err = handlers.register(auth_db, "henry", "notanemail", "pass123")
+        assert not ok
+        assert "email" in err.lower()
+
+    def test_register_short_password(self, auth_db):
+        ok, err = handlers.register(auth_db, "ivan", "ivan@example.com", "12345")
+        assert not ok
+        assert "Password" in err
+
+    def test_register_duplicate_username(self, auth_db):
+        handlers.register(auth_db, "judy", "judy@example.com", "pass123")
+        ok, err = handlers.register(auth_db, "judy", "other@example.com", "pass123")
+        assert not ok
+        assert "taken" in err.lower()
+
+    def test_register_invite_code_required(self, auth_db):
+        ok, err = handlers.register(
+            auth_db, "kent", "kent@example.com", "pass123",
+            invite_code="", required_invite_code="secret"
+        )
+        assert not ok
+
+    def test_register_invite_code_wrong(self, auth_db):
+        ok, err = handlers.register(
+            auth_db, "kent", "kent@example.com", "pass123",
+            invite_code="wrong", required_invite_code="secret"
+        )
+        assert not ok
+
+    def test_register_invite_code_correct(self, auth_db):
+        ok, err = handlers.register(
+            auth_db, "kent", "kent@example.com", "pass123",
+            invite_code="secret", required_invite_code="secret"
+        )
+        assert ok
+
+    def test_change_password_mismatch(self, auth_db):
+        uid = auth_db.create_user("lena", "lena@example.com", "pass123")
+        ok, err = handlers.change_password(auth_db, uid, "pass123", "newpass1", "newpass2")
+        assert not ok
+        assert "match" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Blueprint / route integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestBlueprint:
+    def test_login_success(self, auth_db, client):
+        auth_db.create_user("mary", "mary@example.com", "pass123")
+        r = client.post("/api/login", json={"username": "mary", "password": "pass123"})
+        assert r.status_code == 200
+        assert r.get_json()["success"] is True
+
+    def test_login_wrong_password(self, client):
+        r = client.post("/api/login", json={"username": "nobody", "password": "x"})
+        assert r.status_code == 401
+
+    def test_register_and_login(self, client):
+        r = client.post("/api/register", json={
+            "username": "newuser", "email": "new@example.com", "password": "pass123"
+        })
+        assert r.status_code == 200
+        r = client.post("/api/login", json={"username": "newuser", "password": "pass123"})
+        assert r.status_code == 200
+
+    def test_logout(self, client):
+        r = client.post("/api/logout", json={})
+        assert r.status_code == 200
+
+    def test_change_password_not_logged_in(self, client):
+        r = client.post("/api/user/change-password", json={
+            "current_password": "a", "new_password": "bb", "confirm_password": "bb"
+        })
+        assert r.status_code == 401
+
+    def test_change_password_logged_in(self, auth_db, client):
+        auth_db.create_user("nick", "nick@example.com", "oldpass1")
+        client.post("/api/login", json={"username": "nick", "password": "oldpass1"})
+        r = client.post("/api/user/change-password", json={
+            "current_password": "oldpass1",
+            "new_password": "newpass1",
+            "confirm_password": "newpass1",
+        })
+        assert r.status_code == 200
+        assert r.get_json()["success"] is True
+        # old password no longer works
+        assert auth_db.authenticate("nick", "oldpass1") is None
+        assert auth_db.authenticate("nick", "newpass1") is not None


### PR DESCRIPTION
Adds a reusable Flask auth plugin to fiat-lux-agents.

## What's included

- `fiat_lux_agents/auth/db.py` - AuthDB class with SQLite + Postgres dual support
- `fiat_lux_agents/auth/handlers.py` - register, login, change-password, forgot-password, reset-password logic
- `fiat_lux_agents/auth/blueprint.py` - `make_auth_blueprint()` factory (same pattern as explorer)
- `fiat_lux_agents/auth/tokens.py` - stateless HMAC reset tokens, no extra DB table needed
- `fiat_lux_agents/auth/email.py` - email sender abstraction (Sendgrid HTTP API or SMTP fallback)
- 32 tests

## Usage

```python
from fiat_lux_agents.auth import make_auth_blueprint
auth_bp = make_auth_blueprint(
    get_connection=get_db,
    use_postgres=USE_POSTGRES,
    secret_key=os.environ["SECRET_KEY"],
    app_url="https://myapp.onrender.com",
    from_email="noreply@myapp.com",
    invite_code=os.environ.get("INVITE_CODE", ""),
)
app.register_blueprint(auth_bp)
```

Closes #28