### PR TITLE
forgot-password: return error when email not found

### DIFF
--- a/fiat_lux_agents/auth/handlers.py
+++ b/fiat_lux_agents/auth/handlers.py
@@ -67,18 +67,14 @@ def forgot_password(
     from_email: str,
     app_name: str = "Libertas",
 ) -> tuple[bool, str | None]:
-    """Look up user by email, send reset link. Returns (sent, error).
-
-    Always returns (True, None) even if email not found - avoids leaking
-    whether an address is registered.
-    """
+    """Look up user by email, send reset link. Returns (sent, error)."""
     from .tokens import generate_reset_token
     from . import email as mailer
 
     email = email.strip().lower()
     user = db.get_user_by_email(email)
     if not user:
-        return True, None  # silent - don't reveal if email exists
+        return False, "No account found with that email address"
 
     token = generate_reset_token(user["id"], secret_key)
     reset_url = f"{app_url.rstrip('/')}/reset-password.html?token={token}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -261,10 +261,12 @@ class TestTokens:
 
 
 class TestResetPasswordRoutes:
-    def test_forgot_password_unknown_email_still_200(self, client):
+    def test_forgot_password_unknown_email_returns_error(self, client):
         r = client.post("/api/forgot-password", json={"email": "nobody@example.com"})
-        assert r.status_code == 200
-        assert r.get_json()["success"] is True
+        assert r.status_code == 400
+        data = r.get_json()
+        assert data["success"] is False
+        assert "No account" in data["error"]
 
     def test_forgot_password_sends_for_known_email(self, auth_db, client, monkeypatch):
         import fiat_lux_agents.auth.email as mailer


### PR DESCRIPTION
Instead of silently returning success for unknown emails, return an error so the user knows to try a different address.